### PR TITLE
sed: usable from any dir

### DIFF
--- a/sed
+++ b/sed
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+pwd0=$PWD
+cd -P -- "${0%/*}/"
+
 usage() {
   basename="${0##*/}"
   cat << EOF
@@ -43,7 +46,7 @@ $1"
       f_opt_found=true
       shift; nb_args="$((nb_args - 1))"
       script="$script
-$(cat $1)"
+$(cd "$pwd0"; cat "$1")"
       ;;
     -h|--help)
       usage


### PR DESCRIPTION
Looks like `sed` was only usable as ./sed. By saving `$pwd0` on entry, cd-ing to the script's location, and then resolving `-f`'s relative to `$pwd0`, it should now work from anywhere.

I was trying to use this as a GNU sed alternative for testing purposes, but I couldn't find differences (using non-E BRE's)