### PR TITLE
Sed script libmode

### DIFF
--- a/sed
+++ b/sed
@@ -66,21 +66,19 @@ __sed_main "$@"
 
 __sed_main() { __sed_default_main "$@"; }
 __sed_default_main() {
-: "${SED_DIR:=${0%/*}/}"
-mydir=$SED_DIR
-case "$mydir" in
-  /*) ;;
-  *) mydir=$PWD/$mydir ;;
-esac
+if [ -z "${SED_DIR:-}" ]; then
+  SED_DIR=$0
+  case "$SED_DIR" in
+    /*) ;;
+    *) SED_DIR=$PWD/$0 ;;
+  esac
+  SED_DIR=${SED_DIR%/*}/
+fi
 
-bin="${BIN-$mydir/sed-bin}"
-default_translator=$mydir/par.sed
+bin="${BIN-$SED_DIR/sed-bin}"
+default_translator=$SED_DIR/par.sed
 translator="${SED_TRANSLATOR-$default_translator}"
-generated_file=$mydir/generated.c
-case "$bin" in
-  /*) ;;
-  *) bin=$mydir/$bin ;;
-esac
+generated_file=$SED_DIR/generated.c
 
 if "$e_opt_found" || "$f_opt_found"; then
   # delete extra leading newline, this is important for #n handling
@@ -95,7 +93,7 @@ fi
 __sed_make() { __sed_default_make "$@"; }
 __sed_default_make() {  # args: script
 printf '%s\n' "$1" | "$translator" > "$generated_file" &&
-  make -C "$mydir" -s
+  make -C "$SED_DIR" -s
 }
 __sed_exec() { __sed_default_exec "$@"; }
 __sed_default_exec() {

--- a/sed
+++ b/sed
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -u
 
-__usage() {
+__sed_usage() {
   cat << EOF
 An implementation of sed based on C translation.
 
@@ -28,7 +28,7 @@ while [ "$nb_args" -gt 0 ]; do
     -e)
       e_opt_found=true
       if "$f_opt_found"; then
-        __usage 1 >&2
+        __sed_usage 1 >&2
       fi
 
       shift; nb_args="$((nb_args - 1))"
@@ -42,7 +42,7 @@ $1"
 $(cat "$1")"
       ;;
     -h|--help)
-      __usage
+      __sed_usage
       ;;
     -n)
       n_opt_found=true
@@ -84,7 +84,7 @@ if "$e_opt_found" || "$f_opt_found"; then
   # delete extra leading newline, this is important for #n handling
   script="${script#?}"
 elif ! "$no_opt_script_found"; then
-  __usage 1 >&2
+  __sed_usage 1 >&2
 fi
 
   __sed_make "$script" && __sed_exec "$@"

--- a/sed
+++ b/sed
@@ -65,7 +65,8 @@ done
 sed_main "$@"
 }
 
-sed_main() {
+sed_main() { sed_default_main "$@"; }
+sed_default_main() {
 mydir=${0%/*}/
 case "$mydir" in
   /*) ;;

--- a/sed
+++ b/sed
@@ -92,7 +92,7 @@ fi
 
 __sed_make() { __sed_default_make "$@"; }
 __sed_default_make() {  # args: script
-printf '%s\n' "$1" | "$translator" > "$generated_file" &&
+printf '%s\n' "$1" | (cd -- "$SED_DIR" && "$translator") > "$generated_file" &&
   make -C "$SED_DIR" -s
 }
 __sed_exec() { __sed_default_exec "$@"; }

--- a/sed
+++ b/sed
@@ -97,7 +97,8 @@ __sed_default_make() {  # args: script
 printf '%s\n' "$1" | "$translator" > "$generated_file" &&
   make -C "$mydir" -s
 }
-__sed_exec() {
+__sed_exec() { __sed_default_exec "$@"; }
+__sed_default_exec() {
   case $# in
     0) ;;
 #   1) exec <"$1" ;;  # TODO: will lose filename, maybe add option

--- a/sed
+++ b/sed
@@ -89,11 +89,15 @@ elif ! "$no_opt_script_found"; then
 fi
 
 printf '%s\n' "$script" | "$translator" > "$generated_file" &&
-  make -C "$mydir" -s &&
-  { cat "$@" | sed_exec; }
+  make -C "$mydir" -s && sed_exec "$@"
 }
 
 sed_exec() {
+  case $# in
+    0) ;;
+#   1) exec <"$1" ;;  # TODO: will lose filename, maybe add option
+    *) cat "$@" | sed_exec ;;
+  esac
   if "$n_opt_found"; then
     set -- -n
   fi

--- a/sed
+++ b/sed
@@ -107,7 +107,7 @@ __sed_default_exec() {
   if "$n_opt_found"; then
     set -- -n
   fi
-  "$bin" "$@"
+  exec "$bin" "$@"
 }
 
 if [ -z "${SED_LIBMODE:-}" ]; then

--- a/sed
+++ b/sed
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -u
 
-usage() {
+__usage() {
   basename="${0##*/}"
   cat << EOF
 An implementation of sed based on C translation.
@@ -17,7 +17,7 @@ EOF
   exit "${1-0}"
 }
 
-sed_parse_args() {
+__sed_parse_args() {
 nb_args="$#"
 e_opt_found=false
 f_opt_found=false
@@ -29,7 +29,7 @@ while [ "$nb_args" -gt 0 ]; do
     -e)
       e_opt_found=true
       if "$f_opt_found"; then
-        usage 1 >&2
+        __usage 1 >&2
       fi
 
       shift; nb_args="$((nb_args - 1))"
@@ -43,7 +43,7 @@ $1"
 $(cat "$1")"
       ;;
     -h|--help)
-      usage
+      __usage
       ;;
     -n)
       n_opt_found=true
@@ -62,11 +62,11 @@ $(cat "$1")"
   shift; nb_args="$((nb_args - 1))"
 done
 
-sed_main "$@"
+__sed_main "$@"
 }
 
-sed_main() { sed_default_main "$@"; }
-sed_default_main() {
+__sed_main() { __sed_default_main "$@"; }
+__sed_default_main() {
 mydir=${0%/*}/
 case "$mydir" in
   /*) ;;
@@ -86,22 +86,22 @@ if "$e_opt_found" || "$f_opt_found"; then
   # delete extra leading newline, this is important for #n handling
   script="${script#?}"
 elif ! "$no_opt_script_found"; then
-  usage 1 >&2
+  __usage 1 >&2
 fi
 
-  sed_make "$script" && sed_exec "$@"
+  __sed_make "$script" && __sed_exec "$@"
 }
 
-sed_make() { sed_default_make "$@"; }
-sed_default_make() {  # args: script
+__sed_make() { __sed_default_make "$@"; }
+__sed_default_make() {  # args: script
 printf '%s\n' "$1" | "$translator" > "$generated_file" &&
   make -C "$mydir" -s
 }
-sed_exec() {
+__sed_exec() {
   case $# in
     0) ;;
 #   1) exec <"$1" ;;  # TODO: will lose filename, maybe add option
-    *) cat "$@" | sed_exec ;;
+    *) cat "$@" | __sed_exec ;;
   esac
   if "$n_opt_found"; then
     set -- -n
@@ -110,7 +110,7 @@ sed_exec() {
 }
 
 if [ -z "${SED_LIBMODE:-}" ]; then
-  sed_parse_args "$@"
+  __sed_parse_args "$@"
 else
   eval "$SED_LIBMODE"
 fi

--- a/sed
+++ b/sed
@@ -2,7 +2,6 @@
 set -u
 
 __usage() {
-  basename="${0##*/}"
   cat << EOF
 An implementation of sed based on C translation.
 
@@ -67,7 +66,8 @@ __sed_main "$@"
 
 __sed_main() { __sed_default_main "$@"; }
 __sed_default_main() {
-mydir=${0%/*}/
+: "${SED_DIR:=${0%/*}/}"
+mydir=$SED_DIR
 case "$mydir" in
   /*) ;;
   *) mydir=$PWD/$mydir ;;

--- a/sed
+++ b/sed
@@ -89,10 +89,14 @@ elif ! "$no_opt_script_found"; then
   usage 1 >&2
 fi
 
-printf '%s\n' "$script" | "$translator" > "$generated_file" &&
-  make -C "$mydir" -s && sed_exec "$@"
+  sed_make "$script" && sed_exec "$@"
 }
 
+sed_make() { sed_default_make "$@"; }
+sed_default_make() {  # args: script
+printf '%s\n' "$1" | "$translator" > "$generated_file" &&
+  make -C "$mydir" -s
+}
 sed_exec() {
   case $# in
     0) ;;

--- a/sed
+++ b/sed
@@ -90,13 +90,14 @@ fi
 
 printf '%s\n' "$script" | "$translator" > "$generated_file" &&
   make -C "$mydir" -s &&
-  cat "$@" | {
-    set --
-    if "$n_opt_found"; then
-      set -- -n
-    fi
-    "$bin" "$@"
-  }
+  { cat "$@" | sed_exec; }
+}
+
+sed_exec() {
+  if "$n_opt_found"; then
+    set -- -n
+  fi
+  "$bin" "$@"
 }
 
 if [ -z "${SED_LIBMODE:-}" ]; then

--- a/sed
+++ b/sed
@@ -101,8 +101,8 @@ __sed_exec() { __sed_default_exec "$@"; }
 __sed_default_exec() {
   case $# in
     0) ;;
-#   1) exec <"$1" ;;  # TODO: will lose filename, maybe add option
-    *) cat "$@" | __sed_exec ;;
+    1) exec <"$1"; shift ;;  # will lose filename, but we always do anyway
+    *) cat "$@" | __sed_default_exec ;;
   esac
   if "$n_opt_found"; then
     set -- -n

--- a/sed
+++ b/sed
@@ -75,7 +75,7 @@ if [ -z "${SED_DIR:-}" ]; then
   SED_DIR=${SED_DIR%/*}/
 fi
 
-bin="${BIN-$SED_DIR/sed-bin}"
+bin="${SED_BIN-$SED_DIR/sed-bin}"
 default_translator=$SED_DIR/par.sed
 translator="${SED_TRANSLATOR-$default_translator}"
 generated_file=$SED_DIR/generated.c
@@ -93,7 +93,11 @@ fi
 __sed_make() { __sed_default_make "$@"; }
 __sed_default_make() {  # args: script
 printf '%s\n' "$1" | (cd -- "$SED_DIR" && "$translator") > "$generated_file" &&
-  make -C "$SED_DIR" -s
+  # Makefile's BIN is a single-shell-word basename inside $SED_DIR, can't rely on it
+  BIN=sed-bin make -C "$SED_DIR" -s
+  if [ "$(realpath "$bin")" != "$(realpath "$SED_DIR/sed-bin")" ]; then
+    mv "$SED_DIR/sed-bin" "$bin"
+  fi
 }
 __sed_exec() { __sed_default_exec "$@"; }
 __sed_default_exec() {


### PR DESCRIPTION
I've been working on a version of the [sed script that caches](https://github.com/kstr0k/sed-bin/blob/sed-cached/sed-cached) compiled files. In the process, I reorganized the `sed` script to
- be source-able as a library
- not depend on any `./` files or `cd` commands (by using `make -C` and figuring out absolute paths names for `generated_file` etc).

Besides being *extensible* and not requiring any hacks, I think the reorganized code is somewhat clearer, so I'm opening a pull request.

FWIW, I've benchmarked (results below) `sed-cached` with a simple sed command. It's about 15 times faster than compiling each time, but still twice as slow as native sed (only 75% slower on busybox `sh` with builtin applets). Yeah, it should be written in C not `sh`. But it was a fun as a proof of concept :)

I'm curious what you think of this. Perhaps `sed-cached` can make it to `contrib/`. Perhaps a C version would be even faster than sed, and then maybe `sed-bin` is not so useless after all.

```
hyperfine --export-markdown /tmp/sed-bin.md -w2 -L sed /S/sed-bin/sed,/S/sed-bin/sed-cached,'busybox sh /S/sed-bin/sed-cached',sed 'for i in $(seq 1 5); do {sed} s/:/_/g /etc/passwd; done
```

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `for i in $(seq 1 5); do /S/sed-bin/sed s/:/_/g /etc/passwd; done` | 397.3 ± 8.2 | 383.1 | 408.5 | 33.07 ± 0.84 |
| `for i in $(seq 1 5); do /S/sed-bin/sed-cached s/:/_/g /etc/passwd; done` | 25.5 ± 0.2 | 25.0 | 26.0 | 2.12 ± 0.03 |
| `for i in $(seq 1 5); do busybox sh /S/sed-bin/sed-cached s/:/_/g /etc/passwd; done` | 21.4 ± 0.3 | 19.4 | 22.0 | 1.78 ± 0.04 |
| `for i in $(seq 1 5); do sed s/:/_/g /etc/passwd; done` | 12.0 ± 0.2 | 11.1 | 12.6 | 1.00 |
